### PR TITLE
Add a reworked version of the code of conduct.

### DIFF
--- a/Code_of_conduct_refactored.md
+++ b/Code_of_conduct_refactored.md
@@ -1,0 +1,77 @@
+
+---
+- [Adimian Sprints Citizen Code of Conduct:](#adimian-sprints-citizen-code-of-conduct)
+  - [1. `Objective`](#1-objective)
+  - [2. `Open Citizenship`](#2-open-citizenship)
+  - [3. `Desired Conduct`](#3-desired-conduct)
+  - [4. `Inappropriate Behavior`](#4-inappropriate-behavior)
+  - [5. `Weapons Policy`](#5-weapons-policy)
+  - [6. `Consequences for Misconduct`](#6-consequences-for-misconduct)
+  - [7. `Reporting Procedure`](#7-reporting-procedure)
+  - [8. `Grievance Resolution`](#8-grievance-resolution)
+  - [9. `Applicability`](#9-applicability)
+  - [10. `Contact Information`](#10-contact-information)
+  - [11. `License & Attribution`](#11-license--attribution)
+
+
+# Adimian Sprints Citizen Code of Conduct:
+Welcome to Adimian Sprints, where we strive to bring together a diverse group of contributors! We're all about creating a friendly, safe, and inclusive space for everyone, no matter their background. To make sure everyone feels welcome and respected, we've created this Code of Conduct. Let's work together to create an amazing experience for everyone!
+
+### 1. `Objective`
+Adimian Sprints aims to welcome a diverse array of contributors by fostering an inclusive, friendly, and respectful environment for everyone, irrespective of their gender, sexual orientation, ability, ethnicity, socioeconomic status, or religion. This code outlines expected behavior, consequences of unacceptable actions, and encourages participants to help create positive experiences.
+
+### 2. `Open Citizenship`
+This Code seeks to promote open citizenship by urging participants to understand the connection between their actions and the community's well-being. It encourages recognizing those who make extra efforts to ensure a welcoming and inclusive environment.
+
+
+### 3. `Desired Conduct`
+Community members are expected to:
+
+- Engage authentically and actively, contributing to the community's health and longevity.
+- Be considerate and respectful in speech and actions.
+- Seek collaboration before conflict.
+- Avoid demeaning, discriminatory, or harassing behavior and language.
+- Be aware of surroundings, fellow participants, and any violations of this Code.
+- Respect shared event venues and the public.
+
+### 4. `Inappropriate Behavior`
+The following actions are deemed harassment and are not tolerated:
+- Violent language or threats directed at others.
+- Discriminatory jokes and language.
+- Displaying explicit or violent material.
+- Personal insults targeting gender, orientation, race, religion, or disability.
+- Unauthorized photography or recording.
+- Non-consensual physical contact or unwelcome sexual attention.
+- Intimidation, stalking, or encouraging inappropriate behavior.
+- Disrupting community events, talks, and presentations.
+
+### 5. `Weapons Policy`
+Weapons, including guns, explosives, large knives, or any items intended to cause harm, are prohibited at events and spaces governed by this Code. Offenders will be asked to leave and may return without the weapon. Compliance with local laws is expected.
+
+### 6. `Consequences for Misconduct`
+Misbehavior from anyone, including sponsors and decision-makers, is unacceptable. Offenders must cease such behavior upon request. Consequences for misconduct may include temporary bans or permanent expulsion without warning or refunds for paid events.
+
+### 7. `Reporting Procedure`
+If you witness or experience inappropriate behavior, notify community organizer Eric Gazoni (eric@adimian.com) as soon as possible, providing:
+- Contact information for follow-up.
+- Names of involved individuals and witnesses.
+- Incident specifics: when and where.
+- Description of the incident.
+- Additional context.
+- Ongoing incident status.
+- Any other relevant details.
+
+Community organizers can assist with local law enforcement, ensuring safety, and providing escorts as needed.
+
+### 8. `Grievance Resolution`
+If accused of violating this Code unfairly or falsely, contact Adimian with a concise grievance description. The grievance will be handled per existing policies.
+
+### 9. `Applicability`
+All community participants must abide by this Code in all venues, online and in-person, and in all relevant communications. It also applies to misconduct outside community activities that could impact the safety and well-being of members.
+
+### 10. `Contact Information`
+Eric Gazoni, Adimian CEO ([eric@adimian.com](mailto:eric@adimian.com))
+
+### 11. `License & Attribution`
+Distributed by Stumptown Syndicate under a Creative Commons Attribution-ShareAlike license. Portions of the text are derived from the Django Code of Conduct and the Geek Feminism Anti-Harassment Policy. Revised multiple times with the most recent revision (2.3) posted on 6 March 2017.
+


### PR DESCRIPTION
### Added a more streamlined version of the code of conduct.

#### This PR aims to improve: 
- Accessibility; By increasing the effectiveness of skim-reading inside the Code_of_conduct_refactored (Because we know there will always be those few.) 
- Ease of use; table of contents for quick checking up on specifics inside the code of conduct.
- User attention; this version generally uses less words to describe in more detail.
- Markdown formatting style.

#### This PR is not:
- A sneaky rework of the code of conduct rules.
- A provoking message meant to make a statement.

Disclaimer: If you're an active participant in Adimian Sprints and plan on reading the entire code of conduct please make sure you read the ENTIRE code of conduct and don't take my PR as a reason not to.

Extra-disclaimer: Code_of_conduct_refactored.md was largely generated by GPT-4 in accordance to the guidelines given in my prompt + the original Code of conduct as input. For this reason:

## Please proof-read Code_of_conduct_refactored.md before merging. I have tried my best to conserve the original message as much as possible wherever possible.
